### PR TITLE
Add sysfs based GPIO PWM fallback when DMA isn't available on Raspberry Pi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,8 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-module periph.io/x/host/v3
+//module periph.io/x/host/v3
+module github.com/asssaf/periphio-host
 
 go 1.20
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
+github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 periph.io/x/conn/v3 v3.7.0 h1:f1EXLn4pkf7AEWwkol2gilCNZ0ElY+bxS4WE2PQXfrA=
 periph.io/x/conn/v3 v3.7.0/go.mod h1:ypY7UVxgDbP9PJGwFSVelRRagxyXYfttVh7hJZUHEhg=
 periph.io/x/d2xx v0.1.0 h1:aR+hMkz57YbQHR+Rji4jHH43YLTITRZUr2HjhqCYa7k=


### PR DESCRIPTION
On Raspberry PI, GPIO access can be done through the /dev/gpiomem device without additional privileges. However, for PWM DMA is needed as well which requires full memory access. 
This means when running in docker it needs to run in privileged mode (with --privileged).

The Raspberry PI also supports GPIO access though sysfs, but PWM is not implemented in the sysfs gpio driver.

This change adds PWM support through sysfs and fallback to sysfs in the bcm283x gpio driver when DMA isn't available. It only requires read/write access to sysfs (as a member of the gpio group).

Note that this also uses files under /sys/firmware, which are normally not accessibly in a docker container. To allow access it needs to be run with `--security-opt systempaths=unconfined --security-opt apparmor=unconfined -v /sys:/sys --device /dev/gpiomem`. Alternatively the files in /sys/firmware files can just be copied into the containers manually, they are just used for mapping the pin numbers to the pwm numbers.
